### PR TITLE
fix: Fix Bun/Deno/Node.js FFI to convert HTTP methods into Gleam types

### DIFF
--- a/src/hinoto/body_ffi.mjs
+++ b/src/hinoto/body_ffi.mjs
@@ -5,7 +5,7 @@
  * and convert them to appropriate Gleam types.
  */
 
-import { Ok, Error } from "../gleam.mjs";
+import { Result$Ok, Result$Error, BitArray$BitArray } from "../gleam.mjs";
 import {
   AlreadyRead,
   ParseError,
@@ -16,7 +16,6 @@ import {
   BitArrayBody,
   EmptyBody
 } from "./body.mjs";
-import { BitArray } from "../gleam.mjs";
 
 /**
  * Reads the body content as text (String)
@@ -27,12 +26,12 @@ import { BitArray } from "../gleam.mjs";
 export async function readText(body) {
   // If body is already a StringBody, return it directly
   if (body instanceof StringBody) {
-    return new Ok(body[0]);
+    return Result$Ok(body[0]);
   }
 
   // If body is EmptyBody, return empty string
   if (body instanceof EmptyBody) {
-    return new Ok("");
+    return Result$Ok("");
   }
 
   // If body is RequestBody, read from the Request object
@@ -41,19 +40,19 @@ export async function readText(body) {
 
     // Check if body has already been used
     if (req.bodyUsed) {
-      return new Error(new AlreadyRead());
+      return Result$Error(new AlreadyRead());
     }
 
     try {
       const text = await req.text();
-      return new Ok(text);
+      return Result$Ok(text);
     } catch (e) {
-      return new Error(new ReadError(e.message));
+      return Result$Error(new ReadError(e.message));
     }
   }
 
   // Unsupported body type for text reading
-  return new Error(
+  return Result$Error(
     new UnsupportedBodyType(
       `Cannot read text from body type: ${body.constructor.name}`
     )
@@ -69,12 +68,12 @@ export async function readText(body) {
 export async function readBits(body) {
   // If body is already a BitArrayBody, return it directly
   if (body instanceof BitArrayBody) {
-    return new Ok(body[0]);
+    return Result$Ok(body[0]);
   }
 
   // If body is EmptyBody, return empty BitArray
   if (body instanceof EmptyBody) {
-    return new Ok(new BitArray(new Uint8Array(0)));
+    return Result$Ok(BitArray$BitArray(new Uint8Array(0)));
   }
 
   // If body is RequestBody, read from the Request object
@@ -83,20 +82,20 @@ export async function readBits(body) {
 
     // Check if body has already been used
     if (req.bodyUsed) {
-      return new Error(new AlreadyRead());
+      return Result$Error(new AlreadyRead());
     }
 
     try {
       const arrayBuffer = await req.arrayBuffer();
       const uint8Array = new Uint8Array(arrayBuffer);
-      return new Ok(new BitArray(uint8Array));
+      return Result$Ok(BitArray$BitArray(uint8Array));
     } catch (e) {
-      return new Error(new ReadError(e.message));
+      return Result$Error(new ReadError(e.message));
     }
   }
 
   // Unsupported body type for binary reading
-  return new Error(
+  return Result$Error(
     new UnsupportedBodyType(
       `Cannot read bits from body type: ${body.constructor.name}`
     )
@@ -112,7 +111,7 @@ export async function readBits(body) {
 export async function readJson(body) {
   // If body is EmptyBody, return error
   if (body instanceof EmptyBody) {
-    return new Error(new ParseError("Cannot parse JSON from empty body"));
+    return Result$Error(new ParseError("Cannot parse JSON from empty body"));
   }
 
   // If body is RequestBody, read from the Request object
@@ -121,18 +120,18 @@ export async function readJson(body) {
 
     // Check if body has already been used
     if (req.bodyUsed) {
-      return new Error(new AlreadyRead());
+      return Result$Error(new AlreadyRead());
     }
 
     try {
       const json = await req.json();
-      return new Ok(json);
+      return Result$Ok(json);
     } catch (e) {
       // JSON parsing error or read error
       if (e instanceof SyntaxError) {
-        return new Error(new ParseError(e.message));
+        return Result$Error(new ParseError(e.message));
       }
-      return new Error(new ReadError(e.message));
+      return Result$Error(new ReadError(e.message));
     }
   }
 
@@ -140,14 +139,14 @@ export async function readJson(body) {
   if (body instanceof StringBody) {
     try {
       const json = JSON.parse(body[0]);
-      return new Ok(json);
+      return Result$Ok(json);
     } catch (e) {
-      return new Error(new ParseError(e.message));
+      return Result$Error(new ParseError(e.message));
     }
   }
 
   // Unsupported body type for JSON reading
-  return new Error(
+  return Result$Error(
     new UnsupportedBodyType(
       `Cannot read JSON from body type: ${body.constructor.name}`
     )

--- a/src/hinoto/runtime/ffi.bun.mjs
+++ b/src/hinoto/runtime/ffi.bun.mjs
@@ -1,4 +1,5 @@
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 import {
   Get,
   Post,
@@ -58,9 +59,9 @@ export async function toGleamRequest(req) {
     body: body,
     scheme: url.protocol.replace(':', ''),
     host: url.hostname,
-    port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
+    port: url.port ? new Some(parseInt(url.port)) : new None(),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : undefined,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 

--- a/src/hinoto/runtime/ffi.bun.mjs
+++ b/src/hinoto/runtime/ffi.bun.mjs
@@ -1,4 +1,31 @@
 import { List } from "../../../prelude.mjs";
+import {
+  Get,
+  Post,
+  Put,
+  Delete,
+  Head,
+  Options,
+  Patch,
+  Trace,
+  Connect,
+  Other,
+} from "../../../gleam_http/gleam/http.mjs";
+
+function parseMethod(method) {
+  switch (method.toUpperCase()) {
+    case "GET":     return new Get();
+    case "POST":    return new Post();
+    case "PUT":     return new Put();
+    case "DELETE":  return new Delete();
+    case "HEAD":    return new Head();
+    case "OPTIONS": return new Options();
+    case "PATCH":   return new Patch();
+    case "TRACE":   return new Trace();
+    case "CONNECT": return new Connect();
+    default:        return new Other(method);
+  }
+}
 
 /**
  * Checks if the request body should be read based on HTTP method
@@ -26,7 +53,7 @@ export async function toGleamRequest(req) {
   const headers = List.fromArray([...req.headers]);
 
   return {
-    method: req.method.toUpperCase(),
+    method: parseMethod(req.method),
     headers: headers,
     body: body,
     scheme: url.protocol.replace(':', ''),

--- a/src/hinoto/runtime/ffi.deno.mjs
+++ b/src/hinoto/runtime/ffi.deno.mjs
@@ -1,4 +1,5 @@
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 import {
   Get,
   Post,
@@ -58,9 +59,9 @@ export async function toGleamRequest(req) {
     body: body,
     scheme: url.protocol.replace(':', ''),
     host: url.hostname,
-    port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
+    port: url.port ? new Some(parseInt(url.port)) : new None(),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : undefined,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 

--- a/src/hinoto/runtime/ffi.deno.mjs
+++ b/src/hinoto/runtime/ffi.deno.mjs
@@ -1,4 +1,31 @@
 import { List } from "../../../prelude.mjs";
+import {
+  Get,
+  Post,
+  Put,
+  Delete,
+  Head,
+  Options,
+  Patch,
+  Trace,
+  Connect,
+  Other,
+} from "../../../gleam_http/gleam/http.mjs";
+
+function parseMethod(method) {
+  switch (method.toUpperCase()) {
+    case "GET":     return new Get();
+    case "POST":    return new Post();
+    case "PUT":     return new Put();
+    case "DELETE":  return new Delete();
+    case "HEAD":    return new Head();
+    case "OPTIONS": return new Options();
+    case "PATCH":   return new Patch();
+    case "TRACE":   return new Trace();
+    case "CONNECT": return new Connect();
+    default:        return new Other(method);
+  }
+}
 
 /**
  * Checks if the request body should be read based on HTTP method
@@ -26,7 +53,7 @@ export async function toGleamRequest(req) {
   const headers = List.fromArray([...req.headers]);
 
   return {
-    method: req.method.toUpperCase(),
+    method: parseMethod(req.method),
     headers: headers,
     body: body,
     scheme: url.protocol.replace(':', ''),

--- a/src/hinoto/runtime/ffi.node.mjs
+++ b/src/hinoto/runtime/ffi.node.mjs
@@ -1,5 +1,32 @@
 import { serve as hono_serve } from "@hono/node-server";
 import { List } from "../../../prelude.mjs";
+import {
+  Get,
+  Post,
+  Put,
+  Delete,
+  Head,
+  Options,
+  Patch,
+  Trace,
+  Connect,
+  Other,
+} from "../../../gleam_http/gleam/http.mjs";
+
+function parseMethod(method) {
+  switch (method.toUpperCase()) {
+    case "GET":     return new Get();
+    case "POST":    return new Post();
+    case "PUT":     return new Put();
+    case "DELETE":  return new Delete();
+    case "HEAD":    return new Head();
+    case "OPTIONS": return new Options();
+    case "PATCH":   return new Patch();
+    case "TRACE":   return new Trace();
+    case "CONNECT": return new Connect();
+    default:        return new Other(method);
+  }
+}
 
 /**
  * Checks if the request body should be read based on HTTP method
@@ -27,7 +54,7 @@ export async function toGleamRequest(req) {
   const headers = List.fromArray([...req.headers]);
 
   return {
-    method: req.method.toUpperCase(),
+    method: parseMethod(req.method),
     headers: headers,
     body: body,
     scheme: url.protocol.replace(':', ''),

--- a/src/hinoto/runtime/ffi.node.mjs
+++ b/src/hinoto/runtime/ffi.node.mjs
@@ -1,5 +1,6 @@
 import { serve as hono_serve } from "@hono/node-server";
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 import {
   Get,
   Post,
@@ -59,9 +60,9 @@ export async function toGleamRequest(req) {
     body: body,
     scheme: url.protocol.replace(':', ''),
     host: url.hostname,
-    port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
+    port: url.port ? new Some(parseInt(url.port)) : new None(),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : null,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 

--- a/src/hinoto/runtime/ffi.winterjs.mjs
+++ b/src/hinoto/runtime/ffi.winterjs.mjs
@@ -1,18 +1,18 @@
-import { Ok, Error } from "../../gleam.mjs"
+import { Result$Ok, Result$Error } from "../../gleam.mjs"
 
 export function env_get(env, key) {
     if (!env || !(key in env)) {
-	return Promise.resolve(new Error(undefined))
+	return Promise.resolve(Result$Error(undefined))
     } else {
-	return Promise.resolve(new Ok(env[key]))
+	return Promise.resolve(Result$Ok(env[key]))
     }
 }
 
 export function env_set(env, key, value) {
     if (!env) {
-	return Promise.resolve(new Error(undefined))
+	return Promise.resolve(Result$Error(undefined))
     } else {
 	env[key] = value
-	return Promise.resolve(new Ok(undefined))
+	return Promise.resolve(Result$Ok(undefined))
     }
 }

--- a/src/hinoto/runtime/ffi.workers.mjs
+++ b/src/hinoto/runtime/ffi.workers.mjs
@@ -3,6 +3,7 @@
  */
 
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 import {
   Get,
   Post,
@@ -72,9 +73,9 @@ export function toGleamRequest(req) {
     body: body,
     scheme: url.protocol.replace(':', ''),
     host: url.hostname,
-    port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
+    port: url.port ? new Some(parseInt(url.port)) : new None(),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : undefined,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 


### PR DESCRIPTION
Updated the code to use parseMethod() to convert the request method into the appropriate Gleam http.Method type (such as Get, Post, Put, etc.), instead of returning it as a string via req.method.toUpperCase().

Applied the same fix to Bun, Deno, and Node.js as previously implemented for Cloudflare Workers (#22).

https://claude.ai/code/session_01TpXL9qa3KNXtF72zoE1QGn