### PR TITLE
fix(ffi): use Gleam Option type for query field in all runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 .serena
 .devenv
 .direnv
+/.agent-shell/

--- a/src/hinoto/runtime/ffi.bun.mjs
+++ b/src/hinoto/runtime/ffi.bun.mjs
@@ -1,4 +1,5 @@
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 
 /**
  * Checks if the request body should be read based on HTTP method
@@ -33,7 +34,7 @@ export async function toGleamRequest(req) {
     host: url.hostname,
     port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : undefined,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 

--- a/src/hinoto/runtime/ffi.deno.mjs
+++ b/src/hinoto/runtime/ffi.deno.mjs
@@ -1,4 +1,5 @@
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 
 /**
  * Checks if the request body should be read based on HTTP method
@@ -33,7 +34,7 @@ export async function toGleamRequest(req) {
     host: url.hostname,
     port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : undefined,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 

--- a/src/hinoto/runtime/ffi.node.mjs
+++ b/src/hinoto/runtime/ffi.node.mjs
@@ -1,5 +1,6 @@
 import { serve as hono_serve } from "@hono/node-server";
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 
 /**
  * Checks if the request body should be read based on HTTP method
@@ -34,7 +35,7 @@ export async function toGleamRequest(req) {
     host: url.hostname,
     port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : null,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 

--- a/src/hinoto/runtime/ffi.workers.mjs
+++ b/src/hinoto/runtime/ffi.workers.mjs
@@ -3,6 +3,7 @@
  */
 
 import { List } from "../../../prelude.mjs";
+import { Some, None } from "../../../gleam_stdlib/gleam/option.mjs";
 import {
   Get,
   Post,
@@ -74,7 +75,7 @@ export function toGleamRequest(req) {
     host: url.hostname,
     port: url.port ? parseInt(url.port) : (url.protocol === 'https:' ? 443 : 80),
     path: url.pathname,
-    query: url.search ? url.search.substring(1) : undefined,
+    query: url.search ? new Some(url.search.substring(1)) : new None(),
   };
 }
 


### PR DESCRIPTION
Replace undefined/null with Some/None for the query field in toGleamRequest
across Bun, Deno, Node, and Workers FFI implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment configuration files and added exclusion rules for unnecessary directories.

* **Refactor**
  * Unified runtime query parameter processing to support a more robust type system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Comamoca/hinoto/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->