### PR TITLE
chore(coderabbit): fix ast-grep config key

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,6 +25,11 @@ reviews:
       - main
       - dev
 
+  tools:
+    ast-grep:
+      rule_dirs:
+        - .coderabbit/rules
+
   path_filters:
     - "!build/**"
     - "!_build/**"
@@ -88,9 +93,6 @@ reviews:
 
         - Confirm that test cases covering FFI type conversions are included.
         - Verify that pattern matching for each HTTP method (GET, POST, PUT, DELETE, etc.) works correctly.
-
-ast_grep_instructions:
-  rules_dir: .coderabbit/rules
 
 chat:
   auto_reply: true


### PR DESCRIPTION
Move ast_grep_instructions (unrecognized key) to the correct location
at reviews.tools.ast-grep.rule_dirs per the current schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixed CodeRabbit configuration by moving ast-grep configuration to the correct schema location. The configuration was updated from the unrecognized key `ast_grep_instructions.rules_dir` to the schema-compliant `reviews.tools.ast-grep.rule_dirs` structure.

## Changes

Updated `.coderabbit.yaml` to place the ast-grep rule directory configuration in the correct location within the CodeRabbit schema:
- Moved ast-grep configuration to `tools.ast-grep.rule_dirs`
- Set rule directory path to `.coderabbit/rules`

This ensures the ast-grep tool configuration is properly recognized by the CodeRabbit schema validator.

## Files Modified

- `.coderabbit.yaml`: Configuration structure corrected (+5 lines, -3 lines)

## Impact

Low - Configuration-only change. Ensures proper ast-grep rule detection for code reviews by placing the configuration in the correct schema-defined location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->