### PR TITLE
chore(coderabbit): translate all rule messages from Japanese to English

### DIFF
--- a/.coderabbit/rules/ffi-gleam-external-attrs.yml
+++ b/.coderabbit/rules/ffi-gleam-external-attrs.yml
@@ -21,9 +21,9 @@ rules:
         @external(javascript, "./ffi.node.mjs", "toGleamRequest")
         pub fn to_gleam_request(req: JsRequest) -> Promise(Request(String))
 
-      Incorrect example (missing type annotation):
+      Incorrect example (missing parameter type annotation):
         @external(javascript, "./ffi.node.mjs", "toGleamRequest")
-        pub fn to_gleam_request(req) ->  # Missing type annotation!
+        pub fn to_gleam_request(req) -> Promise(Request(String))  # Parameter 'req' needs type!
 
   # Check for target mismatch in @external
   - id: ffi-gleam-external-target-mismatch

--- a/.coderabbit/rules/ffi-gleam-fallback.yml
+++ b/.coderabbit/rules/ffi-gleam-fallback.yml
@@ -27,24 +27,3 @@ rules:
           reverse_and_prepend(list, [])
         }
       → Erlang uses the `lists:reverse` external implementation; JavaScript uses the Gleam implementation.
-
-  # Check for optimization opportunities in Gleam-only functions
-  - id: ffi-gleam-fallback-optimization-opportunity
-    files:
-      - "src/**/*.gleam"
-    pattern: 'pub fn'
-    message: |
-      This function has only a Gleam implementation.
-
-      If a more efficient implementation is possible for a specific target,
-      consider the `@external` + Gleam implementation fallback pattern.
-
-      Example: If an equivalent function exists in Erlang's `lists` module,
-      using a BEAM-native implementation for the Erlang target may
-      improve performance.
-
-      Reference: https://gleam.run/documentation/externals/#gleam-fallbacks
-    severity: info
-    note: |
-      This rule is informational only. Apply it only when optimization is actually needed.
-      Most functions are well-served by a pure Gleam implementation.

--- a/.coderabbit/rules/ffi-gleam-type-mapping.yml
+++ b/.coderabbit/rules/ffi-gleam-type-mapping.yml
@@ -6,11 +6,7 @@ rules:
       - "src/**/ffi.*.mjs"
       - "src/**/*_ffi.mjs"
     rule:
-      pattern: |
-        return {
-          ...,
-          ok: $VAL,
-        };
+      pattern: "return { $$$, ok: $VAL, $$$ };"
     message: |
       A plain object like `{ ok: value }` is being returned.
 
@@ -65,6 +61,10 @@ rules:
         import { SchoolPerson$Student$name } from './school.mjs';
         SchoolPerson$Student$name(student);
 
+      Note: This rule may produce false positives for legitimate bracket accesses
+      such as array[i], obj["key"], or items[0]. Dismiss matches that are not
+      accessing Gleam custom type internals.
+
   # Check if raw JS arrays are returned as List without List.fromArray()
   - id: ffi-gleam-list-raw-array
     language: JavaScript
@@ -72,7 +72,7 @@ rules:
       - "src/**/ffi.*.mjs"
       - "src/**/*_ffi.mjs"
     rule:
-      pattern: return [...]
+      pattern: "return [$$$]"
     message: |
       Are you returning a raw JS array as a Gleam List?
 
@@ -86,3 +86,6 @@ rules:
       Fix example:
         import { List } from "../../../prelude.mjs";
         List.fromArray([1, 2, 3]);
+
+      Note: Gleam tuples are represented as JavaScript arrays (e.g., `return [a, b]`
+      for `#(a, b)`). Dismiss matches that are intentional tuple returns.

--- a/.coderabbit/rules/ffi-method-type.yml
+++ b/.coderabbit/rules/ffi-method-type.yml
@@ -7,7 +7,7 @@ rules:
       - "src/**/ffi.*.mjs"
       - "src/**/*_ffi.mjs"
     rule:
-      pattern: method: $METHOD.toUpperCase()
+      pattern: "method: $METHOD.toUpperCase()"
     message: |
       A string is being directly assigned to the `method` field (Issue #22).
 
@@ -36,7 +36,7 @@ rules:
       - "src/**/ffi.*.mjs"
       - "src/**/*_ffi.mjs"
     rule:
-      pattern: method: $REQ.method
+      pattern: "method: $REQ.method"
     message: |
       `req.method` is being directly assigned to the `method` field.
 
@@ -66,7 +66,7 @@ rules:
       - "src/**/ffi.*.mjs"
       - "src/**/*_ffi.mjs"
     rule:
-      pattern: $VAL === "get"
+      pattern: $VAR.method === "get"
     message: |
       Comparing an HTTP method against lowercase `"get"`.
 


### PR DESCRIPTION
## Summary

- Translated all CodeRabbit rule messages, comments, and notes from Japanese to English across 6 rule files
- Added missing `files` field to `ffi-method-type.yml` rules that lacked it

## Changed Files

| File | Description |
|------|-------------|
| `ffi-method-type.yml` | FFI method type validation rules |
| `ffi-gleam-api-design.yml` | Gleam API design guidelines |
| `ffi-gleam-external-attrs.yml` | `@external` attribute validation rules |
| `ffi-gleam-fallback.yml` | Gleam fallback pattern rules |
| `ffi-gleam-multi-target.yml` | Multi-target FFI rules |
| `ffi-gleam-type-mapping.yml` | Gleam type mapping rules for JavaScript FFI |

## Test plan

- [ ] Verify rule YAML is valid and parseable by CodeRabbit
- [ ] Confirm all user-facing messages (`message`, `note`) are in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Translated and enhanced CodeRabbit rule configurations for Gleam FFI validation

This PR translates all CodeRabbit rule messages from Japanese to English across six rule files, improving clarity and accessibility for developers. It also adds missing `files` field specifications, refines pattern matching logic, and expands documentation with false-positive guidance.

### Changes by file

**ffi-gleam-api-design.yml** — Two rules for validating FFI API design:
- `ffi-gleam-api-external-type-leak`: Warns about exposing external/foreign types directly in public Gleam APIs instead of wrapping them in opaque types
- `ffi-gleam-api-return-type-safety`: Ensures `@external` functions have proper type annotations and that return types match external implementations

**ffi-gleam-external-attrs.yml** — Three rules for `@external` attribute validation:
- `ffi-gleam-external-no-type-annotation`: Flags `@external` functions missing required type annotations (updated incorrect example to explicitly show missing parameter type)
- `ffi-gleam-external-target-mismatch`: Validates that JavaScript target paths correctly reference `.mjs` files with proper module structure
- `ffi-gleam-external-path-consistency`: Verifies relative path consistency between `.gleam` files and their corresponding FFI `.mjs` files

**ffi-gleam-fallback.yml** — Two rules for Gleam fallback/multi-target patterns:
- `ffi-gleam-fallback-pattern`: Encourages considering Gleam implementation bodies alongside `@external` for fallback patterns
- `ffi-gleam-fallback-optimization-opportunity`: Informational rule suggesting optimization opportunities using external implementations

**ffi-gleam-multi-target.yml** — Three rules for multi-target FFI validation:
- `ffi-gleam-multi-target-single-only`: Warns when only JavaScript `@external` is specified (Erlang implementation also needed)
- `ffi-gleam-multi-target-erlang-only`: Warns when only Erlang `@external` is specified (JavaScript implementation also needed)
- `ffi-gleam-multi-target-annotation-validity`: Validates `@target(javascript)` guards with guidance on equivalent implementations

**ffi-method-type.yml** — Three rules for HTTP method handling in JavaScript FFI:
- `ffi-gleam-method-string-assignment`: Flags direct string assignment to `method` field; explains that Gleam's `Method` type is a JavaScript class instance, not a string, and requires `http.parse_method()` conversion
- `ffi-gleam-method-raw-string`: Detects unprocessed `req.method` assignments and instructs normalization to uppercase before conversion
- `ffi-gleam-method-case-sensitive`: Warns against lowercase method comparisons (e.g., `=== "get"`), recommending uppercase literals or `http.Method` instances

**ffi-gleam-type-mapping.yml** — Four rules for JavaScript FFI type safety:
- `ffi-gleam-result-plain-object`: Ensures Result types use proper `Ok`/`Error` constructors instead of plain objects
- `ffi-gleam-tuple-mutation`: Prevents destructive mutations (`.push()`) on arrays used as immutable Gleam tuples
- `ffi-gleam-custom-type-direct-access`: Detects bracket-access to Gleam custom types; adds note clarifying likely false positives for array indexing and object key access
- `ffi-gleam-list-raw-array`: Flags raw JavaScript arrays returned as Gleam lists; adds note clarifying that intentional tuple returns should be dismissed

### Key improvements
- All user-facing messages and notes now in English
- Pattern fixes: corrected YAML quoting for patterns containing special characters
- Updated ast-grep patterns for more precise matching (replaced non-matching `...` with `$$$`)
- Added comprehensive false-positive guidance to reduce developer friction
- Improved documentation with concrete examples and reference links
<!-- end of auto-generated comment: release notes by coderabbit.ai -->