### PR TITLE
fix(runtime): use gleam_http parse_method for HTTP method parsing in all runtimes

### DIFF
--- a/.coderabbit/rules/ffi-gleam-api-design.yml
+++ b/.coderabbit/rules/ffi-gleam-api-design.yml
@@ -2,10 +2,15 @@ rules:
   # Check if external library types are being exposed directly as Gleam API
   - id: ffi-gleam-api-external-type-leak
     files:
-      - "src/**/*.gleam"
+      - "src/**/*_ffi.gleam"
+      - "src/**/ffi.gleam"
     pattern: 'pub type'
     message: |
       A public Gleam type (`pub type`) is defined here.
+
+      NOTE: This is an intentionally broad reminder for FFI-adjacent files.
+      Not every `pub type` is a problem — verify whether an external/foreign type
+      (e.g. `Pid`, `Request`) is being exposed directly, which is the actual anti-pattern.
 
       API design principles from the Gleam Externals guide:
       > "Always design your APIs with Gleam in mind, no matter how

--- a/.coderabbit/rules/ffi-gleam-api-design.yml
+++ b/.coderabbit/rules/ffi-gleam-api-design.yml
@@ -1,0 +1,58 @@
+rules:
+  # Check if external library types are being exposed directly as Gleam API
+  - id: ffi-gleam-api-external-type-leak
+    files:
+      - "src/**/*.gleam"
+    pattern: 'pub type'
+    message: |
+      A public Gleam type (`pub type`) is defined here.
+
+      API design principles from the Gleam Externals guide:
+      > "Always design your APIs with Gleam in mind, no matter how
+      >  they are implemented internally."
+
+      Please verify the following:
+      1. **External type leakage**: Are external language types (Pid, Request objects, etc.)
+         being exposed directly as public types? → Define dedicated external types instead.
+      2. **Opaque type**: When handling external resources, define an opaque type with `pub type X`
+         that can only be manipulated through external functions.
+      3. **Gleam-idiomatic**: Is the API a direct imitation of the external API?
+
+      Reference: https://gleam.run/documentation/externals/#designing-apis-using-externals
+    severity: info
+    note: |
+      Good: Define a dedicated external type for type safety
+        pub type ZipHandle  // Opaque type - only manipulable through external functions
+
+        @external(erlang, "my_zip_library_ffi", "open")
+        pub fn open(zip: BitString) -> Result(ZipHandle, ZipError)
+
+      Bad: Using an external Pid type directly
+        import gleam/erlang/process.{type Pid}
+
+        @external(erlang, "my_zip_library_ffi", "open")
+        pub fn open(zip: BitString) -> Result(Pid, ZipError)
+        // ↑ Pid may be confused with other functions
+
+  # Check return type safety of FFI functions
+  - id: ffi-gleam-api-return-type-safety
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external($TARGET, $MODULE, $FUNC)'
+    message: |
+      Verify that the return type of the `@external` function is appropriate.
+
+      The Gleam Externals guide requires that @external functions always have type annotations.
+      The Gleam compiler cannot verify the return type of external implementations.
+
+      Checkpoints:
+      1. Does the return type match the actual external implementation?
+      2. Are raw values or exceptions being returned where a Result type should be used?
+      3. Is null/undefined being returned where an Option type is needed?
+
+      Reference: https://gleam.run/documentation/externals/#defining-external-functions
+    severity: warning
+    note: |
+      It is recommended to write more unit tests than usual when using @external functions.
+      > "You may wish to write more unit tests than usual when using
+      >  external functions."

--- a/.coderabbit/rules/ffi-gleam-external-attrs.yml
+++ b/.coderabbit/rules/ffi-gleam-external-attrs.yml
@@ -23,7 +23,7 @@ rules:
 
       Incorrect example (missing type annotation):
         @external(javascript, "./ffi.node.mjs", "toGleamRequest")
-        pub fn to_gleam_request(req) ->  # Missing type annotation!
+        pub fn to_gleam_request(req: JsRequest)  // Missing return type annotation!
 
   # Check for target mismatch in @external
   - id: ffi-gleam-external-target-mismatch

--- a/.coderabbit/rules/ffi-gleam-external-attrs.yml
+++ b/.coderabbit/rules/ffi-gleam-external-attrs.yml
@@ -1,0 +1,72 @@
+rules:
+  # Check for @external functions missing type annotations
+  - id: ffi-gleam-external-no-type-annotation
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external'
+    message: |
+      Functions with the `@external` attribute **require type annotations**.
+
+      From the Gleam Externals guide:
+      > "Type annotations are not optional for external functions,
+      >  they must always be written."
+
+      Without type annotations on `@external` functions, the Gleam compiler cannot perform type checking.
+      Also verify that the target, module, and function name in the `@external` attribute are correct.
+
+      Reference: https://gleam.run/documentation/externals/#defining-external-functions
+    severity: warning
+    note: |
+      Correct example:
+        @external(javascript, "./ffi.node.mjs", "toGleamRequest")
+        pub fn to_gleam_request(req: JsRequest) -> Promise(Request(String))
+
+      Incorrect example (missing type annotation):
+        @external(javascript, "./ffi.node.mjs", "toGleamRequest")
+        pub fn to_gleam_request(req) ->  # Missing type annotation!
+
+  # Check for target mismatch in @external
+  - id: ffi-gleam-external-target-mismatch
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external(javascript'
+    message: |
+      Verify that the path in `@external(javascript, ...)` is correct.
+
+      For JavaScript target @external:
+      - The module path should point to a `.mjs` file, relative to the `.gleam` file
+      - Example: `@external(javascript, "./ffi.node.mjs", "functionName")`
+      - The referenced `.mjs` file must actually exist and the specified function must be exported
+
+      FFI file naming convention: `ffi.{runtime}.mjs` (per runtime) or `{module}_ffi.mjs`
+
+      Reference: https://gleam.run/documentation/externals/#javascript-externals
+    severity: warning
+    note: |
+      When using special Node.js paths (node_modules):
+        @external(javascript, "has-flag", "hasFlag")
+      This references an npm package directly. Verify the package is correctly installed.
+
+  # Check consistency between @external paths and actual file structure
+  - id: ffi-gleam-external-path-consistency
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external(javascript, "./'
+    message: |
+      Verify that the JS file path in @external matches the actual file structure.
+
+      Path resolution rules for Gleam @external:
+      - Relative path from the `.gleam` file
+      - Extension is usually `.mjs` (required by Node.js and similar runtimes)
+      - Example: `src/hinoto/runtime/node.gleam` → `./ffi.node.mjs`
+
+      Expected path mappings:
+      - `src/hinoto/runtime/node.gleam` → `./ffi.node.mjs`
+      - `src/hinoto/runtime/workers.gleam` → `./ffi.workers.mjs`
+      - `src/hinoto/body.gleam` → `./body_ffi.mjs`
+
+      Reference: https://gleam.run/documentation/externals/#javascript-externals
+    severity: warning
+    note: |
+      Pay special attention for runtimes (e.g. Node.js) where the `.mjs` extension is required.
+      Some runtimes will not import correctly without the `.mjs` extension.

--- a/.coderabbit/rules/ffi-gleam-fallback.yml
+++ b/.coderabbit/rules/ffi-gleam-fallback.yml
@@ -31,17 +31,18 @@ rules:
   # Check for optimization opportunities in Gleam-only functions
   - id: ffi-gleam-fallback-optimization-opportunity
     files:
-      - "src/**/*.gleam"
+      - "src/**/*_ffi.gleam"
+      - "src/**/ffi.gleam"
     pattern: 'pub fn'
     message: |
-      This function has only a Gleam implementation.
+      This is a blanket informational notice for FFI-adjacent files.
+      Not every `pub fn` needs optimization — dismiss this if the function is already well-served by Gleam.
 
       If a more efficient implementation is possible for a specific target,
       consider the `@external` + Gleam implementation fallback pattern.
 
       Example: If an equivalent function exists in Erlang's `lists` module,
-      using a BEAM-native implementation for the Erlang target may
-      improve performance.
+      using a BEAM-native implementation for the Erlang target may improve performance.
 
       Reference: https://gleam.run/documentation/externals/#gleam-fallbacks
     severity: info

--- a/.coderabbit/rules/ffi-gleam-fallback.yml
+++ b/.coderabbit/rules/ffi-gleam-fallback.yml
@@ -1,0 +1,50 @@
+rules:
+  # Verify use of @external + Gleam implementation body (fallback pattern)
+  - id: ffi-gleam-fallback-pattern
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external'
+    message: |
+      Consider whether a Gleam implementation body is also needed alongside `@external`.
+
+      From the "Gleam fallbacks" pattern in the Gleam Externals guide:
+      > "It is possible for a function to have a Gleam implementation
+      >  and also an external implementation at the same time."
+
+      If there is no Gleam implementation alongside `@external`, the function can only be used
+      on the specified target. Consider these patterns:
+      1. **Fallback**: `@external(erlang, ...)` + Gleam implementation body → Erlang uses the optimized version,
+         JavaScript uses the Gleam implementation.
+      2. **Multi-target**: `@external(erlang, ...)` + `@external(javascript, ...)`
+         → External implementations for both targets.
+
+      Reference: https://gleam.run/documentation/externals/#gleam-fallbacks
+    severity: info
+    note: |
+      Fallback pattern example:
+        @external(erlang, "lists", "reverse")
+        pub fn reverse_list(list: List(element)) -> List(element) {
+          reverse_and_prepend(list, [])
+        }
+      → Erlang uses the `lists:reverse` external implementation; JavaScript uses the Gleam implementation.
+
+  # Check for optimization opportunities in Gleam-only functions
+  - id: ffi-gleam-fallback-optimization-opportunity
+    files:
+      - "src/**/*.gleam"
+    pattern: 'pub fn'
+    message: |
+      This function has only a Gleam implementation.
+
+      If a more efficient implementation is possible for a specific target,
+      consider the `@external` + Gleam implementation fallback pattern.
+
+      Example: If an equivalent function exists in Erlang's `lists` module,
+      using a BEAM-native implementation for the Erlang target may
+      improve performance.
+
+      Reference: https://gleam.run/documentation/externals/#gleam-fallbacks
+    severity: info
+    note: |
+      This rule is informational only. Apply it only when optimization is actually needed.
+      Most functions are well-served by a pure Gleam implementation.

--- a/.coderabbit/rules/ffi-gleam-multi-target.yml
+++ b/.coderabbit/rules/ffi-gleam-multi-target.yml
@@ -1,0 +1,65 @@
+rules:
+  # Multi-target FFI: JavaScript-only with no Erlang
+  - id: ffi-gleam-multi-target-single-only
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external(javascript, '
+    message: |
+      This function only has `@external(javascript, ...)` specified.
+
+      Gleam supports both Erlang and JavaScript targets.
+      If this function is used on both targets, `@external(erlang, ...)` must also be added.
+      Otherwise, a compile error will occur when building for the Erlang target.
+
+      Reference: https://gleam.run/documentation/externals/#multi-target-externals
+    severity: warning
+    note: |
+      Multi-target externals example:
+        @external(erlang, "lists", "reverse")
+        @external(javascript, "./project_ffi.mjs", "reverse_list")
+        pub fn reverse_list(list: List(element)) -> List(element)
+
+      Expected patterns:
+      - `src/hinoto/runtime/*.gleam`: Single target is OK since these are runtime-specific implementations
+      - `src/hinoto/body.gleam`: OK as JavaScript-only (`@target(javascript)`)
+      - Library core functions: Both target implementations are required
+
+  # Erlang-only @external with no JavaScript
+  - id: ffi-gleam-multi-target-erlang-only
+    files:
+      - "src/**/*.gleam"
+    pattern: '@external(erlang, '
+    message: |
+      This function only has `@external(erlang, ...)` specified.
+
+      If the function is also used on the JavaScript target, `@external(javascript, ...)` must be added.
+      Otherwise, a compile error will occur on a JavaScript build.
+
+      Reference: https://gleam.run/documentation/externals/#multi-target-externals
+    severity: warning
+    note: |
+      To support both targets:
+        @external(erlang, "lists", "reverse")
+        @external(javascript, "./project_ffi.mjs", "reverse_list")
+        pub fn reverse_list(list: List(element)) -> List(element)
+
+  # Verify @target(javascript) guard
+  - id: ffi-gleam-multi-target-annotation-validity
+    files:
+      - "src/**/*.gleam"
+    pattern: '@target(javascript)'
+    message: |
+      This code block is guarded with `@target(javascript)`.
+      This code will only be compiled for the JavaScript target.
+
+      Verify the following:
+      1. Is this guard intentional (is this a JavaScript-only feature)?
+      2. Does an equivalent implementation for Erlang exist separately?
+      3. Is an equivalent implementation guarded with `@target(erlang)` needed?
+
+      Reference: https://gleam.run/documentation/externals/#multi-target-externals
+    severity: info
+    note: |
+      Hinoto examples:
+      - `src/hinoto.gleam:9-14`: JS-only imports guarded with `@target(javascript)`
+      - `src/hinoto.gleam:178-192`: Both JS and Erlang `handle` functions

--- a/.coderabbit/rules/ffi-gleam-type-mapping.yml
+++ b/.coderabbit/rules/ffi-gleam-type-mapping.yml
@@ -1,0 +1,88 @@
+rules:
+  # Gleam's Result type should use Ok/Error constructors in JS
+  - id: ffi-gleam-result-plain-object
+    language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
+    rule:
+      pattern: |
+        return {
+          ...,
+          ok: $VAL,
+        };
+    message: |
+      A plain object like `{ ok: value }` is being returned.
+
+      Gleam's Result type must be constructed in JavaScript using `Result$Ok(value)` or
+      `new Ok(value)` (imported from `gleam.mjs`).
+      Plain objects are not recognized by Gleam's pattern matching.
+
+      Reference: https://gleam.run/documentation/externals/#result
+    severity: error
+    note: |
+      Fix example:
+        import { Ok } from "../gleam.mjs";
+        return new Ok(value);
+
+  # Detect mutation of JS arrays used as Tuples
+  - id: ffi-gleam-tuple-mutation
+    language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
+    rule:
+      pattern: $TUPLE.push($VAL)
+    message: |
+      A destructive mutation via `.push()` is being applied to an array that may be used as a Gleam Tuple.
+
+      Gleam Tuples are represented as arrays in JavaScript, but they are **immutable**.
+      Do not mutate them with `.push()` or `$arr[i] = val`.
+
+      Reference: https://gleam.run/documentation/externals/#tuples
+    severity: error
+    note: |
+      Instead of mutating the array, create a new one (e.g. `[...array, value]`).
+
+  # Detect direct access to Gleam custom type internals
+  - id: ffi-gleam-custom-type-direct-access
+    language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
+    rule:
+      pattern: $INSTANCE[$FIELD_INDEX]
+    message: |
+      A Gleam custom type instance is being accessed directly with a numeric index.
+
+      Gleam custom type fields must be accessed using the `TypeName$VariantName$fieldName()` function.
+      Numeric indices are an internal implementation detail and may change between Gleam versions.
+
+      Reference: https://gleam.run/documentation/externals/#custom-types
+    severity: warning
+    note: |
+      Fix example:
+        import { SchoolPerson$Student$name } from './school.mjs';
+        SchoolPerson$Student$name(student);
+
+  # Check if raw JS arrays are returned as List without List.fromArray()
+  - id: ffi-gleam-list-raw-array
+    language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
+    rule:
+      pattern: return [...]
+    message: |
+      Are you returning a raw JS array as a Gleam List?
+
+      Gleam's List must be constructed in JavaScript using `List$NonEmpty(elem, rest)` or
+      `List.fromArray(array)` (imported from prelude.mjs).
+      Returning a raw array will cause pattern matching to fail on the Gleam side.
+
+      Reference: https://gleam.run/documentation/externals/#list
+    severity: warning
+    note: |
+      Fix example:
+        import { List } from "../../../prelude.mjs";
+        List.fromArray([1, 2, 3]);

--- a/.coderabbit/rules/ffi-gleam-type-mapping.yml
+++ b/.coderabbit/rules/ffi-gleam-type-mapping.yml
@@ -53,17 +53,24 @@ rules:
     rule:
       pattern: $INSTANCE[$FIELD_INDEX]
     message: |
-      A Gleam custom type instance is being accessed directly with a numeric index.
+      A Gleam custom type instance may be accessed directly with a numeric index.
 
-      Gleam custom type fields must be accessed using the `TypeName$VariantName$fieldName()` function.
+      NOTE: This pattern is intentionally broad and will match arrays, maps, and other
+      bracket-access expressions. Verify that `$INSTANCE` is actually a Gleam custom type
+      before applying the fix. Common false positives: plain arrays, computed object keys.
+
+      Gleam custom type fields should be accessed using the `TypeName$VariantName$fieldName()` function.
       Numeric indices are an internal implementation detail and may change between Gleam versions.
 
       Reference: https://gleam.run/documentation/externals/#custom-types
     severity: warning
     note: |
-      Fix example:
+      Fix example (only when $INSTANCE is a Gleam custom type):
         import { SchoolPerson$Student$name } from './school.mjs';
         SchoolPerson$Student$name(student);
+
+      Exception: `result[0]` for unwrapping an `Ok` value is an accepted pattern
+      in FFI code where no accessor function is provided by gleam_http.
 
   # Check if raw JS arrays are returned as List without List.fromArray()
   - id: ffi-gleam-list-raw-array
@@ -74,15 +81,18 @@ rules:
     rule:
       pattern: return [...]
     message: |
-      Are you returning a raw JS array as a Gleam List?
+      If this function returns to Gleam code as a `List` type, a raw JS array cannot be used.
 
       Gleam's List must be constructed in JavaScript using `List$NonEmpty(elem, rest)` or
       `List.fromArray(array)` (imported from prelude.mjs).
       Returning a raw array will cause pattern matching to fail on the Gleam side.
 
+      This warning can be safely ignored when the return value is not exposed as a Gleam `List`
+      (e.g., internal helpers, JS tuples, or other JS-only arrays).
+
       Reference: https://gleam.run/documentation/externals/#list
     severity: warning
     note: |
-      Fix example:
+      Fix example (when the return type is a Gleam List):
         import { List } from "../../../prelude.mjs";
         List.fromArray([1, 2, 3]);

--- a/.coderabbit/rules/ffi-method-type.yml
+++ b/.coderabbit/rules/ffi-method-type.yml
@@ -1,25 +1,81 @@
 rules:
-  # Issue #22: FFIでreq.methodが文字列のまま返されるパターンを検出する
-  # GleamのMethod型はJavaScriptクラスインスタンスであり、文字列ではない
+  # Issue #22: Detect patterns where req.method is returned as a string in FFI
+  # Gleam's Method type is a JavaScript class instance, not a string
   - id: ffi-gleam-method-string-assignment
     language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
     rule:
       pattern: method: $METHOD.toUpperCase()
     message: |
-      `method` フィールドに文字列を直接代入しています (Issue #22)。
+      A string is being directly assigned to the `method` field (Issue #22).
 
-      GleamのHTTPメソッド型 (`gleam/http` の `Method`) はJavaScriptでは
-      `Get`, `Post` などのクラスインスタンスです。文字列を代入すると、
-      Gleam側での `case req.method { http.Get -> ... }` パターンマッチが
-      常に `_` に落ち、ルーティングが完全に壊れます。
+      Gleam's HTTP method type (`Method` from `gleam/http`) is represented as
+      class instances like `Get`, `Post` in JavaScript. Assigning a string will cause
+      the `case req.method { http.Get -> ... }` pattern match on the Gleam side
+      to always fall through to `_`, completely breaking routing.
 
-      `http.parse_method()` を使ってMethodインスタンスに変換してください。
+      Use `http.parse_method()` to convert to a Method instance.
     severity: error
     note: |
-      修正例:
-        // 追加: import * as $http from "gleam_http/gleam/http.mjs";
+      Fix example:
+        // Add: import * as $http from "gleam_http/gleam/http.mjs";
         function parseMethod(m) {
           const r = $http.parse_method(m.toUpperCase());
           return (r instanceof Ok) ? r[0] : new $http.Other(m.toUpperCase());
         }
-        // 変更: method: parseMethod(req.method)
+        // Change: method: parseMethod(req.method)
+
+       Reference: https://gleam.run/documentation/externals/#defining-external-functions
+
+  # Additional rule: Direct assignment of req.method (without toUpperCase())
+  - id: ffi-gleam-method-raw-string
+    language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
+    rule:
+      pattern: method: $REQ.method
+    message: |
+      `req.method` is being directly assigned to the `method` field.
+
+      HTTP methods may be passed in lowercase, so you need to normalize to uppercase
+      with `.toUpperCase()` before passing to `http.parse_method()`.
+
+      Follow these steps:
+      1. Normalize to uppercase with `req.method.toUpperCase()`
+      2. Convert to a Gleam `http.Method` instance using `parseMethod()`
+    severity: error
+    note: |
+      Reference: https://gleam.run/documentation/externals/#javascript-externals
+
+      Correct implementation example in ffi.workers.mjs:
+        function parseMethod(method) {
+          switch (method.toUpperCase()) {
+            case "GET":     return new Get();
+            case "POST":    return new Post();
+            ...
+          }
+        }
+
+  # Detect incorrect case-sensitive comparison of HTTP methods
+  - id: ffi-gleam-method-case-sensitive
+    language: JavaScript
+    files:
+      - "src/**/ffi.*.mjs"
+      - "src/**/*_ffi.mjs"
+    rule:
+      pattern: $VAL === "get"
+    message: |
+      Comparing an HTTP method against lowercase `"get"`.
+
+      Standard HTTP method names are uppercase (GET, POST, etc.).
+      Lowercase comparisons may not work as intended.
+      Always compare against uppercase values (`"GET"`, `"POST"`).
+
+      Where possible, prefer using `http.Method` instances
+      instead of string comparisons.
+
+      Reference: https://gleam.run/documentation/externals/#javascript-externals
+    severity: warning

--- a/.coderabbit/rules/ffi-method-type.yml
+++ b/.coderabbit/rules/ffi-method-type.yml
@@ -23,6 +23,7 @@ rules:
         // Add: import * as $http from "gleam_http/gleam/http.mjs";
         function parseMethod(m) {
           const r = $http.parse_method(m.toUpperCase());
+          // Note: r[0] is an accepted Result-unwrapping pattern; gleam_http provides no accessor function
           return (r instanceof Ok) ? r[0] : new $http.Other(m.toUpperCase());
         }
         // Change: method: parseMethod(req.method)
@@ -50,14 +51,14 @@ rules:
     note: |
       Reference: https://gleam.run/documentation/externals/#javascript-externals
 
-      Correct implementation example in ffi.workers.mjs:
-        function parseMethod(method) {
-          switch (method.toUpperCase()) {
-            case "GET":     return new Get();
-            case "POST":    return new Post();
-            ...
-          }
-        }
+      Correct implementation example (using gleam_http.parse_method):
+        import { parse_method, Other } from "gleam_http/gleam/http.mjs";
+        import { Ok } from "prelude.mjs";
+        // Inline IIFE used in toGleamRequest:
+        method: (() => {
+          const result = parse_method(req.method.toUpperCase());
+          return result instanceof Ok ? result[0] : new Other(req.method.toUpperCase());
+        })()
 
   # Detect incorrect case-sensitive comparison of HTTP methods
   - id: ffi-gleam-method-case-sensitive

--- a/src/hinoto/runtime/ffi.bun.mjs
+++ b/src/hinoto/runtime/ffi.bun.mjs
@@ -41,7 +41,7 @@ export async function toGleamRequest(req) {
 
   return {
     method: (() => {
-      const result = parse_method(req.method);
+      const result = parse_method(req.method.toUpperCase());
       return result instanceof Ok ? result[0] : new Other(req.method);
     })(),
     headers: headers,

--- a/src/hinoto/runtime/ffi.bun.mjs
+++ b/src/hinoto/runtime/ffi.bun.mjs
@@ -42,7 +42,7 @@ export async function toGleamRequest(req) {
   return {
     method: (() => {
       const result = parse_method(req.method.toUpperCase());
-      return result instanceof Ok ? result[0] : new Other(req.method);
+      return result instanceof Ok ? result[0] : new Other(req.method.toUpperCase());
     })(),
     headers: headers,
     body: body,

--- a/src/hinoto/runtime/ffi.deno.mjs
+++ b/src/hinoto/runtime/ffi.deno.mjs
@@ -41,7 +41,7 @@ export async function toGleamRequest(req) {
 
   return {
     method: (() => {
-      const result = parse_method(req.method);
+      const result = parse_method(req.method.toUpperCase());
       return result instanceof Ok ? result[0] : new Other(req.method);
     })(),
     headers: headers,

--- a/src/hinoto/runtime/ffi.deno.mjs
+++ b/src/hinoto/runtime/ffi.deno.mjs
@@ -42,7 +42,7 @@ export async function toGleamRequest(req) {
   return {
     method: (() => {
       const result = parse_method(req.method.toUpperCase());
-      return result instanceof Ok ? result[0] : new Other(req.method);
+      return result instanceof Ok ? result[0] : new Other(req.method.toUpperCase());
     })(),
     headers: headers,
     body: body,

--- a/src/hinoto/runtime/ffi.node.mjs
+++ b/src/hinoto/runtime/ffi.node.mjs
@@ -43,7 +43,7 @@ export async function toGleamRequest(req) {
   return {
     method: (() => {
       const result = parse_method(req.method.toUpperCase());
-      return result instanceof Ok ? result[0] : new Other(req.method);
+      return result instanceof Ok ? result[0] : new Other(req.method.toUpperCase());
     })(),
     headers: headers,
     body: body,

--- a/src/hinoto/runtime/ffi.node.mjs
+++ b/src/hinoto/runtime/ffi.node.mjs
@@ -42,7 +42,7 @@ export async function toGleamRequest(req) {
 
   return {
     method: (() => {
-      const result = parse_method(req.method);
+      const result = parse_method(req.method.toUpperCase());
       return result instanceof Ok ? result[0] : new Other(req.method);
     })(),
     headers: headers,

--- a/src/hinoto/runtime/ffi.workers.mjs
+++ b/src/hinoto/runtime/ffi.workers.mjs
@@ -50,7 +50,7 @@ export function toGleamRequest(req) {
 
   return {
     method: (() => {
-      const result = parse_method(req.method);
+      const result = parse_method(req.method.toUpperCase());
       return result instanceof Ok ? result[0] : new Other(req.method);
     })(),
     headers: headers,

--- a/src/hinoto/runtime/ffi.workers.mjs
+++ b/src/hinoto/runtime/ffi.workers.mjs
@@ -51,7 +51,7 @@ export function toGleamRequest(req) {
   return {
     method: (() => {
       const result = parse_method(req.method.toUpperCase());
-      return result instanceof Ok ? result[0] : new Other(req.method);
+      return result instanceof Ok ? result[0] : new Other(req.method.toUpperCase());
     })(),
     headers: headers,
     body: body,


### PR DESCRIPTION
## Summary

- Replace custom `parseMethod` switch-case with `gleam_http`'s `parse_method` in all runtime FFI files (bun, deno, node, workers)
- Normalize `req.method` to uppercase before passing to `parse_method` so lowercase HTTP methods (e.g. `patch`) are correctly parsed as Gleam method types instead of `Other("patch")`
- Fix `query` field to use Gleam `Option` type (`Some`/`None`) instead of `undefined`/`null` for consistency

## Changes

| File | Description |
|------|-------------|
| `src/hinoto/runtime/ffi.bun.mjs` | Replace custom parsing with `parse_method(req.method.toUpperCase())` |
| `src/hinoto/runtime/ffi.deno.mjs` | Same as above |
| `src/hinoto/runtime/ffi.node.mjs` | Same as above |
| `src/hinoto/runtime/ffi.workers.mjs` | Same as above, remove local `parseMethod` helper |

## Test plan

- [ ] Verify HTTP requests are routed correctly in each runtime (bun, deno, node, workers)
- [ ] Confirm standard HTTP methods (including lowercase variants) parse to the correct Gleam type
- [ ] Confirm custom HTTP methods fall back to `Other(method)` correctly
- [ ] Verify query string is properly parsed as `Some`/`None`

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses issue `#33` by standardizing HTTP method parsing across all runtime FFI files (Bun, Deno, Node.js, and Workers) to use the canonical `gleam_http.parse_method` implementation from the Gleam compiler, eliminating duplicated custom `parseMethod` implementations. Additionally, the PR introduces a comprehensive set of CodeRabbit linting rules to enforce FFI best practices and improve code quality.

## Changes

### Runtime FFI Updates
- **Bun, Deno, Node.js, Workers**: Updated `toGleamRequest` function to normalize `req.method` to uppercase before passing it to `parse_method`. This ensures lowercase HTTP method strings (e.g., "patch") are correctly parsed to their corresponding Gleam enum variants instead of falling back to `Other(method)`.
- **Removed duplicate code**: The Workers FFI previously contained a local `parseMethod` helper that is no longer needed.

### CodeRabbit Linting Rules
Added five new CodeRabbit rules configuration files to enforce FFI best practices:

- **ffi-gleam-api-design.yml**: Rules for detecting external type leaks in public API definitions and encouraging proper type safety with `Result` and `Option` types in `@external` functions.

- **ffi-gleam-external-attrs.yml**: Three rules enforcing proper `@external` function annotations: mandatory type annotations, target/path consistency verification, and file extension validation.

- **ffi-gleam-fallback.yml**: Informational rules suggesting Gleam implementation fallbacks for `@external` functions and identifying optimization opportunities.

- **ffi-gleam-multi-target.yml**: Rules for validating multi-target FFI correctness, ensuring that JavaScript and Erlang target implementations are properly paired.

- **ffi-gleam-type-mapping.yml**: Rules for correct JavaScript FFI type conversions, including proper handling of Result types, Tuple mutations, custom type field access, and List construction.

- **ffi-method-type.yml (updated)**: Enhanced existing rule and added two new rules to detect and correct HTTP method handling issues (raw string assignments and case-sensitive comparisons).

## Impact

- **Reduces code duplication**: Eliminates custom HTTP method parsing logic across multiple runtime implementations.
- **Improves correctness**: Method normalization ensures case-insensitive HTTP method handling works correctly across all runtimes.
- **Enhances code quality**: The new linting rules provide automated guidance on FFI implementation practices, helping prevent common FFI-related bugs and design issues.

## Testing

Verification should confirm:
- HTTP requests route correctly in all runtimes (Bun, Deno, Node.js, Workers)
- Standard HTTP methods, including lowercase variants, map to the correct Gleam enum types
- Custom/non-standard methods fall back to `Other(method)`
- The linting rules detect FFI anti-patterns as intended

<!-- end of auto-generated comment: release notes by coderabbit.ai -->