### PR TITLE
fix: Dependency Dashboard

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 gleam = "latest"
 node = "latest"
-"npm:wrangler" = "4.122.0"
+"npm:wrangler" = "4.123.0"
 deno = "latest"
 bun = "latest"


### PR DESCRIPTION
Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the `npm:wrangler` tool from `4.122.0` to `4.123.0` in `mise.toml`.
- Resolves the pending Dependency Dashboard update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->